### PR TITLE
Fixed memory leak in pbjson

### DIFF
--- a/src/pbjson.cpp
+++ b/src/pbjson.cpp
@@ -246,7 +246,10 @@ namespace pbjson
 
             const Reflection *ref = msg->GetReflection();
             if (!ref)
+            {
+                delete root;
                 return NULL;
+            }
             if (field->is_optional() && !ref->HasField(*msg, field))
             {
                 //do nothing


### PR DESCRIPTION
There is the potential of leaking memory if msg->GetReflection() returns NULL