### PR TITLE
Fix for GenericValue(google::protobuf::int64)’ is ambiguous.

### DIFF
--- a/src/pbjson.cpp
+++ b/src/pbjson.cpp
@@ -101,7 +101,7 @@ namespace pbjson
                 }
                 else
                 {
-                    json = new rapidjson::Value(ref->GetInt64(*msg, field));
+                    json = new rapidjson::Value(static_cast<int64_t>(ref->GetInt64(*msg, field)));
                 }
                 break;
             case FieldDescriptor::CPPTYPE_UINT64:
@@ -116,7 +116,7 @@ namespace pbjson
                 }
                 else
                 {
-                    json = new rapidjson::Value(ref->GetUInt64(*msg, field));
+                    json = new rapidjson::Value(static_cast<uint64_t>(ref->GetUInt64(*msg, field)));
                 }
                 break;
             case FieldDescriptor::CPPTYPE_INT32:


### PR DESCRIPTION
Fixed compile error: call of overloaded ‘GenericValue(google::protobuf::int64)’ is ambiguous. Tested on gcc-4.9, gcc-5, clang 3.7 and Visual Studio 2013 using the latest version of protobuf.

If you do not like having the static_cast, it can be changed to a C style cast.